### PR TITLE
Add code to close S3 objects when repository objects are deleted

### DIFF
--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
@@ -173,8 +173,7 @@ public class S3Repository implements ArtifactRepository {
         final String key = objectKey(tenant, sha1Hash);
 
         LOG.info("Deleting S3 object from bucket {} and key {}", s3Properties.getBucketName(), key);
-        final S3Object s3Object = amazonS3.getObject(s3Properties.getBucketName(), key);
-        closeS3Object(s3Object);
+        closeS3Object(amazonS3.getObject(s3Properties.getBucketName(), key));
         amazonS3.deleteObject(new DeleteObjectRequest(s3Properties.getBucketName(), key));
     }
 
@@ -250,8 +249,7 @@ public class S3Repository implements ArtifactRepository {
         ObjectListing objects = amazonS3.listObjects(s3Properties.getBucketName(), folder + "/");
         do {
             for (final S3ObjectSummary objectSummary : objects.getObjectSummaries()) {
-                final S3Object s3Object = amazonS3.getObject(s3Properties.getBucketName(), objectSummary.getKey());
-                closeS3Object(s3Object);
+                closeS3Object(amazonS3.getObject(s3Properties.getBucketName(), objectSummary.getKey()));
             	amazonS3.deleteObject(s3Properties.getBucketName(), objectSummary.getKey());
             }
             objects = amazonS3.listNextBatchOfObjects(objects);

--- a/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
+++ b/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.BufferedInputStream;
@@ -131,6 +132,11 @@ public class S3RepositoryTest {
         assertThat(artifactBySha1.getSize()).isEqualTo(knownContentLength);
         assertThat(artifactBySha1.getHashes().getSha1()).isEqualTo(knownSHA1Hash);
         assertThat(artifactBySha1.getHashes().getMd5()).isEqualTo(knownMdBase16);
+        try {
+            verify(s3ObjectMock).close();
+        } catch (IOException e) {
+            fail("close() caused IOException");
+        }
     }
 
     @Test


### PR DESCRIPTION
Add code to close S3 objects when repository objects are deleted; update test. This should help prevent memory leaks.

Signed-off-by: Bob Dietrich <bob.dietrich@rigado.com>