### PR TITLE
add necessary validator for MongoDBArtifactStore

### DIFF
--- a/hawkbit-extension-artifact-repository-mongo/pom.xml
+++ b/hawkbit-extension-artifact-repository-mongo/pom.xml
@@ -59,6 +59,11 @@
          <artifactId>spring-boot-starter-logging</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-validator</artifactId>
+         <scope>test</scope>
+      </dependency>
       <!-- MongoDB -->
       <dependency>
          <groupId>de.flapdoodle.embed</groupId>


### PR DESCRIPTION
Due the dependency `hibernate-validator` has been removed from the `hawkbit-core` it's not longer on the classpath anymore when executing the `MongoDBArtifactStoreTest` and fails with no valid validator on the classpath.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>