### PR TITLE
Save temp storage in GridFS implementation.

### DIFF
--- a/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
+++ b/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
@@ -140,14 +140,14 @@ public class MongoDBArtifactStore extends AbstractArtifactRepository {
 
     @Override
     protected String storeTempFile(final InputStream content) {
-        final String fileName = findUnusedTemFileName();
+        final String fileName = findUnusedTempFileName();
 
         gridFs.store(content, getTempFilename(fileName));
 
         return fileName;
     }
 
-    private String findUnusedTemFileName() {
+    private String findUnusedTempFileName() {
         String fileName;
         do {
             fileName = UUID.randomUUID().toString();

--- a/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
+++ b/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
@@ -76,7 +76,7 @@ public class MongoDBArtifactStoreTest {
         assertThat(loaded.getContentType()).isEqualTo("application/json");
         assertThat(loaded.getHashes().getSha1()).isEqualTo(sha1Hash16);
         assertThat(loaded.getHashes().getMd5()).isEqualTo(md5Hash16);
-        assertThat(loaded.getSize()).isEqualTo(128);
+        assertThat(loaded.getSize()).isEqualTo(filelengthBytes);
 
         return sha1Hash16;
     }

--- a/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
+++ b/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.artifact.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
@@ -46,7 +47,7 @@ public class MongoDBArtifactStoreTest {
 
     @Test
     @Description("Ensures that search by SHA1 hash (which is used by hawkBit as artifact ID) finds the expected results.")
-    public void findArtifactBySHA1Hash() throws NoSuchAlgorithmException {
+    public void findArtifactBySHA1Hash() throws NoSuchAlgorithmException, IOException {
 
         final String sha1 = storeRandomArifactAndVerify(TENANT);
         final String sha2 = storeRandomArifactAndVerify(TENANT2);
@@ -56,7 +57,7 @@ public class MongoDBArtifactStoreTest {
     }
 
     @Step
-    private String storeRandomArifactAndVerify(final String tenant) throws NoSuchAlgorithmException {
+    private String storeRandomArifactAndVerify(final String tenant) throws NoSuchAlgorithmException, IOException {
         final int filelengthBytes = 128;
         final String filename = "testfile.json";
         final String contentType = "application/json";
@@ -64,10 +65,10 @@ public class MongoDBArtifactStoreTest {
         final MessageDigest mdSHA1 = MessageDigest.getInstance("SHA1");
         final MessageDigest mdMD5 = MessageDigest.getInstance("MD5");
 
-        final DigestInputStream digestInputStream = wrapInDigestInputStream(generateInputStream(filelengthBytes),
-                mdSHA1, mdMD5);
-        artifactStoreUnderTest.store(tenant, digestInputStream, filename, contentType, null);
-
+        try (final DigestInputStream digestInputStream = wrapInDigestInputStream(generateInputStream(filelengthBytes),
+                mdSHA1, mdMD5)) {
+            artifactStoreUnderTest.store(tenant, digestInputStream, filename, contentType, null);
+        }
         final String sha1Hash16 = BaseEncoding.base16().lowerCase().encode(mdSHA1.digest());
         final String md5Hash16 = BaseEncoding.base16().lowerCase().encode(mdMD5.digest());
 
@@ -83,7 +84,7 @@ public class MongoDBArtifactStoreTest {
 
     @Test
     @Description("Deletes file from repository identified by SHA1 hash as filename.")
-    public void deleteArtifactBySHA1Hash() throws NoSuchAlgorithmException {
+    public void deleteArtifactBySHA1Hash() throws NoSuchAlgorithmException, IOException {
 
         final String sha1 = storeRandomArifactAndVerify(TENANT);
 
@@ -94,7 +95,7 @@ public class MongoDBArtifactStoreTest {
     @Test
     @Description("Verfies that all data of a tenant is erased if repository is asked to do so. "
             + "Data of other tenants is not affected.")
-    public void deleteTenant() throws NoSuchAlgorithmException {
+    public void deleteTenant() throws NoSuchAlgorithmException, IOException {
 
         final String shaDeleted = storeRandomArifactAndVerify(TENANT);
         final String shaUndeleted = storeRandomArifactAndVerify("another_tenant");

--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
@@ -9,13 +9,10 @@
 package org.eclipse.hawkbit.artifact.repository;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
 import org.eclipse.hawkbit.artifact.repository.model.AbstractDbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
@@ -34,7 +31,6 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.io.BaseEncoding;
-import com.google.common.io.ByteStreams;
 
 /**
  * An {@link ArtifactRepository} implementation for the AWS S3 service. All
@@ -51,9 +47,6 @@ import com.google.common.io.ByteStreams;
  */
 @Validated
 public class S3Repository extends AbstractArtifactRepository {
-    private static final String TEMP_FILE_PREFIX = "tmp";
-    private static final String TEMP_FILE_SUFFIX = "artifactrepo";
-
     private static final Logger LOG = LoggerFactory.getLogger(S3Repository.class);
 
     private final AmazonS3 amazonS3;
@@ -102,27 +95,6 @@ public class S3Repository extends AbstractArtifactRepository {
             return s3Artifact;
         } catch (final AmazonClientException e) {
             throw new ArtifactStoreException("Failed to store artifact into S3 ", e);
-        }
-    }
-
-    @Override
-    protected String storeTempFile(final InputStream content) throws IOException {
-        final File file = createTempFile();
-
-        try (final OutputStream outputstream = new BufferedOutputStream(new FileOutputStream(file))) {
-            ByteStreams.copy(content, outputstream);
-            outputstream.flush();
-        }
-
-        return file.getPath();
-    }
-
-    private static File createTempFile() {
-
-        try {
-            return File.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_SUFFIX);
-        } catch (final IOException e) {
-            throw new ArtifactStoreException("Cannot create tempfile", e);
         }
     }
 
@@ -199,15 +171,6 @@ public class S3Repository extends AbstractArtifactRepository {
             objects = amazonS3.listNextBatchOfObjects(objects);
         } while (objects.isTruncated());
 
-    }
-
-    @Override
-    protected void deleteTempFile(final String tempFile) {
-        final File file = new File(tempFile);
-
-        if (file.exists() && !file.delete()) {
-            LOG.error("Could not delete temp file {}", file);
-        }
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.2.0M8</version>
+      <version>0.2.0-SNAPSHOT</version>
    </parent>
    
    <artifactId>hawkbit-extensions-parent</artifactId>
@@ -39,7 +39,7 @@
 
    <properties>
       <jacoco.outputDir>${project.basedir}/../../target/</jacoco.outputDir>
-      <hawkbit.version>0.2.0M8</hawkbit.version>
+      <hawkbit.version>0.2.0-SNAPSHOT</hawkbit.version>
       
       <!-- Release - START -->
       <release.scm.connection>scm:git:git@github.com:eclipse/hawkbit-extensions.git</release.scm.connection>


### PR DESCRIPTION
The implementation currently stores the file locally before uploading to MongoDB to calculate the hashes.

The new mechanism now streams directly into MongoDB and simply updates the (hash) metadata later.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>