### PR TITLE
feat: allow overwrite aws region through application.properties

### DIFF
--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryAutoConfiguration.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryAutoConfiguration.java
@@ -15,6 +15,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Optional;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
@@ -31,6 +33,10 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 @EnableConfigurationProperties(S3RepositoryProperties.class)
 public class S3RepositoryAutoConfiguration {
 
+
+	@Value("${aws.region:#{null}}")
+private Optional<String> region;
+
     /**
      * The {@link DefaultAWSCredentialsProviderChain} looks for credentials in
      * this order:
@@ -46,9 +52,6 @@ public class S3RepositoryAutoConfiguration {
      * @return the {@link DefaultAWSCredentialsProviderChain} if no other
      *         {@link AWSCredentialsProvider} bean is registered.
      */
-	
-	@Value("${aws.region:}")
-	private String region;
 	
     @Bean
     @ConditionalOnMissingBean
@@ -76,8 +79,13 @@ public class S3RepositoryAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public AmazonS3 amazonS3() {
-        return AmazonS3ClientBuilder.standard().withCredentials(awsCredentialsProvider())
-                .withClientConfiguration(awsClientConfiguration()).withRegion(region).build();
+        AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard()//
+                .withCredentials(awsCredentialsProvider())//
+                .withClientConfiguration(awsClientConfiguration());
+        if (region.isPresent()) {
+            s3ClientBuilder = s3ClientBuilder.withRegion(region.get());
+        }
+        return s3ClientBuilder.build();
     }
 
     /**

--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryAutoConfiguration.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryAutoConfiguration.java
@@ -35,7 +35,7 @@ public class S3RepositoryAutoConfiguration {
 
 
 	@Value("${aws.region:#{null}}")
-private Optional<String> region;
+    private Optional<String> region;
 
     /**
      * The {@link DefaultAWSCredentialsProviderChain} looks for credentials in

--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryAutoConfiguration.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryAutoConfiguration.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.artifact.repository;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -45,6 +46,10 @@ public class S3RepositoryAutoConfiguration {
      * @return the {@link DefaultAWSCredentialsProviderChain} if no other
      *         {@link AWSCredentialsProvider} bean is registered.
      */
+	
+	@Value("${aws.region:}")
+	private String region;
+	
     @Bean
     @ConditionalOnMissingBean
     public AWSCredentialsProvider awsCredentialsProvider() {
@@ -72,7 +77,7 @@ public class S3RepositoryAutoConfiguration {
     @ConditionalOnMissingBean
     public AmazonS3 amazonS3() {
         return AmazonS3ClientBuilder.standard().withCredentials(awsCredentialsProvider())
-                .withClientConfiguration(awsClientConfiguration()).build();
+                .withClientConfiguration(awsClientConfiguration()).withRegion(region).build();
     }
 
     /**


### PR DESCRIPTION
**Problem Statement**: File upload fails if S3 bucket is not created in `eu-central-1`

**Root Cause**: Application not allowing to set region

**Solution**: AWS region is by default `eu-central-1`. With application property `aws.region` this can be over written.

Signed-off-by: Subhadip Pramanik <pramaniksubhadip@gmail.com>