### PR TITLE
Add multi user extension

### DIFF
--- a/hawkbit-extension-multi-user/README.md
+++ b/hawkbit-extension-multi-user/README.md
@@ -1,0 +1,25 @@
+# hawkBit multi user extension
+
+This extension allows you to statically configure multiple users through the application properties.
+When the extension is enabled but no users are configured, it will fall back to the standard security.user configuration.
+
+## Example configuration
+
+A list of permissions with description is [available from the hawkBit repository](https://github.com/eclipse/hawkbit/blob/master/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java).
+Additionally, if a single permission with the name *ALL* is configured, that user will be granted all available permissions.
+
+    multiuser.user[0].username=admin
+    multiuser.user[0].password=admin
+    multiuser.user[0].firstname=Test
+    multiuser.user[0].lastname=Admin
+    multiuser.user[0].email=admin@test.de
+    multiuser.user[0].permissions[0]=ALL
+    multiuser.user[1].username=test
+    multiuser.user[1].password=test
+    multiuser.user[1].firstname=Test
+    multiuser.user[1].lastname=Tester
+    multiuser.user[1].email=test@tester.com
+    multiuser.user[1].permissions[0]=READ_TARGET
+    multiuser.user[1].permissions[1]=UPDATE_TARGET
+    multiuser.user[1].permissions[2]=CREATE_TARGET
+    multiuser.user[1].permissions[3]=DELETE_TARGET

--- a/hawkbit-extension-multi-user/README.md
+++ b/hawkbit-extension-multi-user/README.md
@@ -8,18 +8,19 @@ When the extension is enabled but no users are configured, it will fall back to 
 A list of permissions with description is [available from the hawkBit repository](https://github.com/eclipse/hawkbit/blob/master/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java).
 Additionally, if a single permission with the name *ALL* is configured, that user will be granted all available permissions.
 
-    multiuser.user[0].username=admin
-    multiuser.user[0].password=admin
-    multiuser.user[0].firstname=Test
-    multiuser.user[0].lastname=Admin
-    multiuser.user[0].email=admin@test.de
-    multiuser.user[0].permissions[0]=ALL
-    multiuser.user[1].username=test
-    multiuser.user[1].password=test
-    multiuser.user[1].firstname=Test
-    multiuser.user[1].lastname=Tester
-    multiuser.user[1].email=test@tester.com
-    multiuser.user[1].permissions[0]=READ_TARGET
-    multiuser.user[1].permissions[1]=UPDATE_TARGET
-    multiuser.user[1].permissions[2]=CREATE_TARGET
-    multiuser.user[1].permissions[3]=DELETE_TARGET
+    hawkbit.server.im.users[0].username=admin
+    hawkbit.server.im.users[0].password={noop}admin
+    hawkbit.server.im.users[0].firstname=Test
+    hawkbit.server.im.users[0].lastname=Admin
+    hawkbit.server.im.users[0].email=admin@test.de
+    hawkbit.server.im.users[0].permissions=ALL
+    
+    hawkbit.server.im.users[1].username=test
+    hawkbit.server.im.users[1].password={noop}test
+    hawkbit.server.im.users[1].firstname=Test
+    hawkbit.server.im.users[1].lastname=Tester
+    hawkbit.server.im.users[1].email=test@tester.com
+    hawkbit.server.im.users[1].permissions=READ_TARGET,UPDATE_TARGET,CREATE_TARGET,DELETE_TARGET
+
+The password encoder used is specified in brackets. In this example, *noop* is used as the plaintext encoder.
+For production use, it is recommended to use a hash function designed for passwords such as *bcrypt*. See this [blog post](https://spring.io/blog/2017/11/01/spring-security-5-0-0-rc1-released#password-storage-format) for more information on password encoders in Spring Security 5.

--- a/hawkbit-extension-multi-user/pom.xml
+++ b/hawkbit-extension-multi-user/pom.xml
@@ -1,3 +1,13 @@
+<!--
+
+    Copyright (c) 2019 devolo AG and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
 

--- a/hawkbit-extension-multi-user/pom.xml
+++ b/hawkbit-extension-multi-user/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.eclipse.hawkbit</groupId>
+      <artifactId>hawkbit-extensions-parent</artifactId>
+      <version>0.3.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>hawkbit-extension-multi-user</artifactId>
+   <name>hawkBit :: Extensions :: Multi User</name>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.eclipse.hawkbit</groupId>
+         <artifactId>hawkbit-security-core</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-autoconfigure</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-security</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-core</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-test</artifactId>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
+</project>

--- a/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/InMemoryMultiUserManagementAutoConfiguration.java
+++ b/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/InMemoryMultiUserManagementAutoConfiguration.java
@@ -17,7 +17,6 @@ import org.eclipse.hawkbit.im.authentication.PermissionUtils;
 import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
 import org.eclipse.hawkbit.im.authentication.UserPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -60,7 +59,7 @@ public class InMemoryMultiUserManagementAutoConfiguration extends GlobalAuthenti
     public UserDetailsService userDetailsService() {
         final String defaultTenant = "DEFAULT";
         final List<UserPrincipal> userPrincipals = new ArrayList<>();
-        for (MultiUserProperties.User user : multiUserProperties.getUser()) {
+        for (MultiUserProperties.User user : multiUserProperties.getUsers()) {
             List<GrantedAuthority> authorityList;
             // Allows ALL as a shorthand for all permissions
             if (user.getPermissions().size() == 1 && user.getPermissions().get(0).equals("ALL")) {

--- a/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/InMemoryMultiUserManagementAutoConfiguration.java
+++ b/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/InMemoryMultiUserManagementAutoConfiguration.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2019 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.hawkbit.security.multiuser;
 
 import java.util.ArrayList;

--- a/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/InMemoryMultiUserManagementAutoConfiguration.java
+++ b/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/InMemoryMultiUserManagementAutoConfiguration.java
@@ -1,0 +1,117 @@
+package org.eclipse.hawkbit.security.multiuser;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import org.eclipse.hawkbit.im.authentication.MultitenancyIndicator;
+import org.eclipse.hawkbit.im.authentication.PermissionUtils;
+import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.eclipse.hawkbit.im.authentication.UserPrincipal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.core.Ordered;
+
+@Configuration
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@EnableConfigurationProperties({ MultiUserProperties.class })
+public class InMemoryMultiUserManagementAutoConfiguration extends GlobalAuthenticationConfigurerAdapter {
+
+    @Autowired
+    private MultiUserProperties multiUserProperties;
+
+    @Autowired
+    private SecurityProperties securityProperties;
+
+    @Override
+    public void configure(final AuthenticationManagerBuilder auth) throws Exception {
+        final DaoAuthenticationProvider userDaoAuthenticationProvider = new TenantDaoAuthenticationProvider();
+        userDaoAuthenticationProvider.setUserDetailsService(userDetailsService());
+        auth.authenticationProvider(userDaoAuthenticationProvider);
+    }
+
+    /**
+     * @return the user details service to load a user from memory user manager.
+     */
+    @Bean
+    public UserDetailsService userDetailsService() {
+        final String defaultTenant = "DEFAULT";
+        final List<UserDetails> userDetails = new ArrayList<>();
+        for (MultiUserProperties.User user : multiUserProperties.getUser()) {
+            List<GrantedAuthority> authorityList;
+            // Allows ALL as a shorthand for all permissions
+            if (user.getPermissions().size() == 1 && user.getPermissions().get(0).equals("ALL"))
+                authorityList = PermissionUtils.createAllAuthorityList();
+            else
+                authorityList = PermissionUtils.createAuthorityList(user.getPermissions());
+            final UserPrincipal userPrincipal = new UserPrincipal(user.getUsername(), user.getPassword(),
+                    user.getFirstname(), user.getLastname(), user.getUsername(), user.getEmail(), defaultTenant,
+                    authorityList);
+            userDetails.add(userPrincipal);
+        }
+
+        // If no users are configured through the multi user properties, set up
+        // the default user from security properties
+        if (userDetails.isEmpty()) {
+            final String name = securityProperties.getUser().getName();
+            final String password = securityProperties.getUser().getPassword();
+            userDetails.add(new UserPrincipal(name, password, name, name, name, null, defaultTenant,
+                    PermissionUtils.createAllAuthorityList()));
+        }
+
+        return new FixedInMemoryUserDetailsService(userDetails);
+    }
+
+    private static class FixedInMemoryUserDetailsService implements UserDetailsService {
+        private final HashMap<String, UserDetails> userDetailsMap = new HashMap<>();
+
+        public FixedInMemoryUserDetailsService(Collection<UserDetails> userDetails) {
+            for (UserDetails user : userDetails) {
+                userDetailsMap.put(user.getUsername(), user);
+            }
+        }
+
+        @Override
+        public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+            UserDetails userDetails = userDetailsMap.get(username);
+            if (userDetails == null)
+                throw new UsernameNotFoundException("No such user");
+            return userDetails;
+        }
+
+    }
+
+    /**
+     * @return the multi-tenancy indicator to disallow multi-tenancy
+     */
+    @Bean
+    public MultitenancyIndicator multiTenancyIndicator() {
+        return () -> false;
+    }
+
+    private static class TenantDaoAuthenticationProvider extends DaoAuthenticationProvider {
+        @Override
+        protected Authentication createSuccessAuthentication(final Object principal,
+                final Authentication authentication, final UserDetails user) {
+            final UsernamePasswordAuthenticationToken result = new UsernamePasswordAuthenticationToken(principal,
+                    authentication.getCredentials(), user.getAuthorities());
+            result.setDetails(new TenantAwareAuthenticationDetails("DEFAULT", false));
+            return result;
+        }
+    }
+
+}

--- a/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/MultiUserProperties.java
+++ b/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/MultiUserProperties.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2019 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.hawkbit.security.multiuser;
 
 import java.util.ArrayList;

--- a/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/MultiUserProperties.java
+++ b/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/MultiUserProperties.java
@@ -13,16 +13,16 @@ import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties("multiuser")
+@ConfigurationProperties("hawkbit.server.im")
 public class MultiUserProperties {
-    private List<User> user = new ArrayList<>();
+    private List<User> users = new ArrayList<>();
 
-    public List<User> getUser() {
-        return user;
+    public List<User> getUsers() {
+        return users;
     }
 
-    public void setUser(List<User> user) {
-        this.user = user;
+    public void setUsers(List<User> users) {
+        this.users = users;
     }
 
     public static class User {

--- a/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/MultiUserProperties.java
+++ b/hawkbit-extension-multi-user/src/main/java/org/eclipse/hawkbit/security/multiuser/MultiUserProperties.java
@@ -1,0 +1,76 @@
+package org.eclipse.hawkbit.security.multiuser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("multiuser")
+public class MultiUserProperties {
+    private List<User> user = new ArrayList<>();
+
+    public List<User> getUser() {
+        return user;
+    }
+
+    public void setUser(List<User> user) {
+        this.user = user;
+    }
+
+    public static class User {
+        private String username;
+        private String password;
+        private String firstname;
+        private String lastname;
+        private String email;
+        private List<String> permissions = new ArrayList<>();
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public String getFirstname() {
+            return firstname;
+        }
+
+        public void setFirstname(String firstname) {
+            this.firstname = firstname;
+        }
+
+        public String getLastname() {
+            return lastname;
+        }
+
+        public void setLastname(String lastname) {
+            this.lastname = lastname;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public List<String> getPermissions() {
+            return permissions;
+        }
+
+        public void setPermissions(List<String> permissions) {
+            this.permissions = permissions;
+        }
+    }
+}

--- a/hawkbit-extension-multi-user/src/main/resources/META-INF/spring.factories
+++ b/hawkbit-extension-multi-user/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Auto Configure
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.eclipse.hawkbit.security.multiuser.InMemoryMultiUserManagementAutoConfiguration

--- a/licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt
+++ b/licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt
@@ -1,0 +1,6 @@
+Copyright (c) 2019 devolo AG and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
       <module>hawkbit-extension-artifact-repository-s3</module>
       <module>hawkbit-extensions-azure</module>
       <module>hawkbit-extended-runtimes</module>
+      <module>hawkbit-extension-multi-user</module>
    </modules>
 
    <build>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
                   <validHeader>licenses/LICENSE_HEADER_TEMPLATE_SIEMENS_18.txt</validHeader>
                   <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH.txt</validHeader>
                   <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
+                  <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt</validHeader>
                </validHeaders>
                <excludes>
                   <exclude>**/helm/**</exclude>


### PR DESCRIPTION
Allows statically configuring multiple users with specific permissions and details. When loaded but no users are configured, the standard behavior with a single user configured through the security properties is emulated.