### PR TITLE
Vaadin 8 migration aftermath for upcoming hawkBit 0.3.0M7

### DIFF
--- a/hawkbit-extended-runtimes/hawkbit-update-server-azure/src/main/java/org/eclipse/hawkbit/app/AzureUI.java
+++ b/hawkbit-extended-runtimes/hawkbit-update-server-azure/src/main/java/org/eclipse/hawkbit/app/AzureUI.java
@@ -8,22 +8,23 @@
  */
 package org.eclipse.hawkbit.app;
 
+import com.vaadin.annotations.Push;
+import com.vaadin.shared.communication.PushMode;
+import com.vaadin.shared.ui.ui.Transport;
+import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.navigator.SpringViewProvider;
+
 import org.eclipse.hawkbit.ui.AbstractHawkbitUI;
 import org.eclipse.hawkbit.ui.ErrorView;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.components.NotificationUnreadButton;
 import org.eclipse.hawkbit.ui.menu.DashboardMenu;
 import org.eclipse.hawkbit.ui.push.EventPushStrategy;
+import org.eclipse.hawkbit.ui.push.UIEventProvider;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.vaadin.spring.events.EventBus.UIEventBus;
-
-import com.vaadin.annotations.Push;
-import com.vaadin.shared.communication.PushMode;
-import com.vaadin.shared.ui.ui.Transport;
-import com.vaadin.spring.annotation.SpringUI;
-import com.vaadin.spring.navigator.SpringViewProvider;
 
 /**
  * hawkBit UI implementation.
@@ -34,11 +35,11 @@ public class AzureUI extends AbstractHawkbitUI {
     private static final long serialVersionUID = 1L;
 
     @Autowired
-    AzureUI(final EventPushStrategy pushStrategy, final UIEventBus eventBus, final SpringViewProvider viewProvider,
-            final ApplicationContext context, final DashboardMenu dashboardMenu, final ErrorView errorview,
-            final NotificationUnreadButton notificationUnreadButton, final UiProperties uiProperties,
-            final VaadinMessageSource i18n) {
-        super(pushStrategy, eventBus, viewProvider, context, dashboardMenu, errorview, notificationUnreadButton,
-                uiProperties, i18n);
+    AzureUI(final EventPushStrategy pushStrategy, final UIEventBus eventBus, final UIEventProvider eventProvider,
+            final SpringViewProvider viewProvider, final ApplicationContext context, final DashboardMenu dashboardMenu,
+            final ErrorView errorview, final NotificationUnreadButton notificationUnreadButton,
+            final UiProperties uiProperties, final VaadinMessageSource i18n) {
+        super(pushStrategy, eventBus, eventProvider, viewProvider, context, dashboardMenu, errorview,
+                notificationUnreadButton, uiProperties, i18n);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0M6</version>
+      <version>0.3.0M7</version>
     </parent>
 
     <artifactId>hawkbit-extensions-parent</artifactId>
@@ -41,7 +41,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0M6</hawkbit.version>
+      <hawkbit.version>0.3.0M7</hawkbit.version>
       <aws.sdk.version>1.11.415</aws.sdk.version>
       <gcp.sdk.version>0.77.0-alpha</gcp.sdk.version>
 


### PR DESCRIPTION
As soon as `0.3.0M7` of hawkBit is available we need to adapt the UI classes in order to reflect the changes introduced by Vaadin 8 migration

Note: The build failure is expected until the extension parent is pointing to `0.3.0M7` of hawkBit