### PR TITLE
JUnit5 support

### DIFF
--- a/hawkbit-extension-artifact-repository-gcs/pom.xml
+++ b/hawkbit-extension-artifact-repository-gcs/pom.xml
@@ -59,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>io.qameta.allure</groupId>
-            <artifactId>allure-junit4</artifactId>
+            <artifactId>allure-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/hawkbit-extension-artifact-repository-gcs/src/test/java/org/eclipse/hawkbit/artifact/repository/GcsRepositoryTest.java
+++ b/hawkbit-extension-artifact-repository-gcs/src/test/java/org/eclipse/hawkbit/artifact/repository/GcsRepositoryTest.java
@@ -29,9 +29,9 @@ import java.util.Random;
 
 import org.eclipse.hawkbit.artifact.repository.model.AbstractDbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -47,11 +47,12 @@ import com.google.common.io.ByteStreams;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Test class for the {@link GcsRepository}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 @Feature("Unit Tests - GCS Repository")
 @Story("GCS Artifact Repository")
 public class GcsRepositoryTest {
@@ -70,7 +71,7 @@ public class GcsRepositoryTest {
     private ArgumentCaptor<BlobInfo> blobCaptor;
     private GcsRepository gcsRepositoryUnderTest;
 
-    @Before
+    @BeforeEach
     public void before() {
         gcsStorageMock = mock(Storage.class);
         gcsRepositoryUnderTest = new GcsRepository(gcsStorageMock, gcpProperties);

--- a/hawkbit-extension-artifact-repository-mongo/pom.xml
+++ b/hawkbit-extension-artifact-repository-mongo/pom.xml
@@ -60,7 +60,7 @@
       </dependency>
       <dependency>
          <groupId>io.qameta.allure</groupId>
-         <artifactId>allure-junit4</artifactId>
+         <artifactId>allure-junit5</artifactId>
          <scope>test</scope>
       </dependency>
       <!-- MongoDB -->

--- a/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
+++ b/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
@@ -22,11 +22,9 @@ import io.qameta.allure.Description;
 import org.eclipse.hawkbit.artifact.TestConfiguration;
 import org.eclipse.hawkbit.artifact.repository.model.AbstractDbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import com.google.common.io.BaseEncoding;
 
@@ -36,7 +34,6 @@ import io.qameta.allure.Story;
 
 @Feature("Component Tests - Repository")
 @Story("Artifact Store MongoDB")
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = {MongoDBArtifactStoreAutoConfiguration.class, TestConfiguration.class}, properties = {
         "spring.data.mongodb.port=0", "spring.mongodb.embedded.version=3.5.5",
         "spring.mongodb.embedded.features=sync_delay,no_http_interface_arg"})

--- a/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
+++ b/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
@@ -18,6 +18,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 
+import io.qameta.allure.Description;
 import org.eclipse.hawkbit.artifact.TestConfiguration;
 import org.eclipse.hawkbit.artifact.repository.model.AbstractDbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
@@ -25,7 +26,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Description;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.google.common.io.BaseEncoding;

--- a/hawkbit-extension-artifact-repository-s3/pom.xml
+++ b/hawkbit-extension-artifact-repository-s3/pom.xml
@@ -56,7 +56,7 @@
       </dependency>
       <dependency>
          <groupId>io.qameta.allure</groupId>
-         <artifactId>allure-junit4</artifactId>
+         <artifactId>allure-junit5</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
+++ b/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
@@ -30,14 +30,13 @@ import java.util.Random;
 
 import org.eclipse.hawkbit.artifact.repository.model.AbstractDbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -49,13 +48,15 @@ import com.google.common.io.ByteStreams;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Test class for the {@link S3Repository}.
  */
-@RunWith(MockitoJUnitRunner.class)
+
 @Feature("Unit Tests - S3 Repository")
 @Story("S3 Artifact Repository")
+@ExtendWith(MockitoExtension.class)
 public class S3RepositoryTest {
 
     private static final String TENANT = "test_tenant";
@@ -81,7 +82,7 @@ public class S3RepositoryTest {
     private final S3RepositoryProperties s3Properties = new S3RepositoryProperties();
     private S3Repository s3RepositoryUnderTest;
 
-    @Before
+    @BeforeEach
     public void before() {
         amazonS3Mock = mock(AmazonS3.class);
         s3RepositoryUnderTest = new S3Repository(amazonS3Mock, s3Properties);

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0M6</version>
+      <version>0.3.0M7</version>
     </parent>
 
     <artifactId>hawkbit-extensions-parent</artifactId>
@@ -41,7 +41,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0M6</hawkbit.version>
+      <hawkbit.version>0.3.0M7</hawkbit.version>
       <aws.sdk.version>1.11.415</aws.sdk.version>
       <gcp.sdk.version>0.77.0-alpha</gcp.sdk.version>
 


### PR DESCRIPTION
Reflecting changes from https://github.com/eclipse/hawkbit/pull/1063

Note: The build failure is expected until `0.3.0M7` of hawkBit is available containing required JUnit5 setup