### PR TITLE
Fix open S3Object InputStream

### DIFF
--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
@@ -10,8 +10,13 @@ package org.eclipse.hawkbit.artifact.repository;
 
 import java.io.InputStream;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.google.common.io.BaseEncoding;
 import org.eclipse.hawkbit.artifact.repository.model.AbstractDbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 import com.amazonaws.services.s3.AmazonS3;
@@ -22,11 +27,22 @@ import com.amazonaws.services.s3.AmazonS3;
  */
 public class S3Artifact extends AbstractDbArtifact {
 
+    private static final Logger LOG = LoggerFactory.getLogger(S3Artifact.class);
+
     private final AmazonS3 amazonS3;
     private final S3RepositoryProperties s3Properties;
     private final String key;
+    private S3Object s3Object;
 
-    S3Artifact(final AmazonS3 amazonS3, final S3RepositoryProperties s3Properties, final String key,
+
+    private S3Artifact(final S3Object s3Object, final AmazonS3 amazonS3, final S3RepositoryProperties s3Properties,
+            final String key, final String artifactId, final DbArtifactHash hashes, final Long size,
+            final String contentType) {
+        this(amazonS3, s3Properties, key, artifactId, hashes, size, contentType);
+        this.s3Object = s3Object;
+    }
+
+    private S3Artifact(final AmazonS3 amazonS3, final S3RepositoryProperties s3Properties, final String key,
             final String artifactId, final DbArtifactHash hashes, final Long size, final String contentType) {
         super(artifactId, hashes, size, contentType);
         Assert.notNull(amazonS3, "S3 cannot be null");
@@ -37,9 +53,62 @@ public class S3Artifact extends AbstractDbArtifact {
         this.key = key;
     }
 
-    @Override
-    public InputStream getFileInputStream() {
-        return amazonS3.getObject(s3Properties.getBucketName(), key).getObjectContent();
+    /**
+     * Get an S3Artifact for an already existing binary in the repository based on
+     * the given key.
+     *
+     * @param amazonS3
+     *            connection to the AmazonS3
+     * @param s3Properties
+     *            used to retrieve the bucket name
+     * @param key
+     *            of the artifact
+     * @param artifactId
+     *            sha1Hash to create the {@link DbArtifactHash}
+     * @return an instance of {@link S3Artifact}
+     * @throws S3ArtifactNotFoundException
+     *             in case that no artifact could be found for the given values
+     */
+    public static S3Artifact get(final AmazonS3 amazonS3, final S3RepositoryProperties s3Properties, final String key,
+            final String artifactId) throws S3ArtifactNotFoundException {
+        final S3Object s3Object = getS3ObjectOrThrowException(amazonS3, s3Properties.getBucketName(), key);
+
+        final ObjectMetadata objectMetadata = s3Object.getObjectMetadata();
+        final DbArtifactHash artifactHash = createArtifactHash(artifactId, objectMetadata);
+        return new S3Artifact(s3Object, amazonS3, s3Properties, key, artifactId, artifactHash,
+                objectMetadata.getContentLength(), objectMetadata.getContentType());
+    }
+
+    /**
+     * Create a new instance of {@link S3Artifact}. In this case it is not checked
+     * if an artifact with the given values exists. The S3 object is empty.
+     *
+     * @param amazonS3
+     *            connection to the AmazonS3
+     * @param s3Properties
+     *            used to retrieve the bucket name
+     * @param key
+     *            of the artifact
+     * @param hashes
+     *            instance of {@link DbArtifactHash}
+     * @param size
+     *            of the artifact
+     * @param contentType
+     *            of the artifact
+     * @return an instance of {@link S3Artifact} with an empty {@link S3Object}
+     */
+    public static S3Artifact create(final AmazonS3 amazonS3, final S3RepositoryProperties s3Properties,
+            final String key, final DbArtifactHash hashes, final Long size, final String contentType) {
+        return new S3Artifact(amazonS3, s3Properties, key, hashes.getSha1(), hashes, size, contentType);
+    }
+
+    /**
+     * Verify if the {@link S3Object} exists
+     *
+     * @return result of {@link AmazonS3}#doesObjectExist
+     */
+    public boolean exists(){
+        return amazonS3.doesObjectExist(s3Properties.getBucketName(), key);
     }
 
     @Override
@@ -47,4 +116,39 @@ public class S3Artifact extends AbstractDbArtifact {
         return "S3Artifact [key=" + key + ", getArtifactId()=" + getArtifactId() + ", getHashes()=" + getHashes()
                 + ", getSize()=" + getSize() + ", getContentType()=" + getContentType() + "]";
     }
+
+    @Override
+    public InputStream getFileInputStream() {
+        LOG.debug("Get file input stream for s3 object with key {}", key);
+        return getS3Object().getObjectContent();
+    }
+
+    private S3Object getS3Object() {
+        if (s3Object == null) {
+            LOG.debug("Initialize S3Object in bucket {} with key {}", s3Properties.getBucketName(), key);
+            s3Object = amazonS3.getObject(s3Properties.getBucketName(), key);
+        }
+        return s3Object;
+    }
+
+    private static S3Object getS3ObjectOrThrowException(AmazonS3 amazonS3, String bucketName, String key)
+            throws S3ArtifactNotFoundException {
+        final S3Object s3Object = amazonS3.getObject(bucketName, key);
+        if (s3Object == null) {
+            throw new S3ArtifactNotFoundException("Cannot find s3 object by given arguments.", bucketName, key);
+        }
+        return s3Object;
+    }
+
+    private static DbArtifactHash createArtifactHash(final String artifactId, ObjectMetadata metadata) {
+        return new DbArtifactHash(artifactId, BaseEncoding.base16().lowerCase()
+                .encode(BaseEncoding.base64().decode(sanitizeEtag(metadata.getETag()))), null);
+    }
+
+    private static String sanitizeEtag(final String etag) {
+        // base64 alphabet consist of alphanumeric characters and + / = (see RFC
+        // 4648)
+        return etag.trim().replaceAll("[^A-Za-z0-9+/=]", "");
+    }
+
 }

--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
@@ -25,7 +25,7 @@ import com.amazonaws.services.s3.AmazonS3;
  * An {@link AbstractDbArtifact} implementation which retrieves the
  * {@link InputStream} from the {@link AmazonS3} client.
  */
-public class S3Artifact extends AbstractDbArtifact {
+public final class S3Artifact extends AbstractDbArtifact {
 
     private static final Logger LOG = LoggerFactory.getLogger(S3Artifact.class);
 

--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3ArtifactNotFoundException.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3ArtifactNotFoundException.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.artifact.repository;
+
+/**
+ * An exception that is thrown as soon as an S3 object could not be found in a S3 bucket.
+ */
+public class S3ArtifactNotFoundException extends RuntimeException {
+
+    private final String bucket;
+    private final String key;
+
+    /**
+     * Constructor with individual error message and information about the searched
+     * artifact.
+     *
+     * @param message
+     *            use an individual error message here.
+     *
+     * @param bucket
+     *            the bucket of the searched artifact.
+     * @param key
+     *            the key of the searched artifact (mostly kind of
+     *            'tenant/sha1hash').
+     */
+    public S3ArtifactNotFoundException(final String message, final String bucket, final String key) {
+        super(message);
+        this.bucket = bucket;
+        this.key = key;
+    }
+
+    /**
+     * Constructor with individual error message with a cause and information about
+     * the searched artifact.
+     *
+     * @param message
+     *            use an individual error message here.
+     *
+     * @param cause
+     *            the cause of the exception.
+     * @param bucket
+     *            the bucket of the searched artifact.
+     * @param key
+     *            the key of the searched artifact (mostly kind of
+     *            'tenant/sha1hash').
+     */
+    public S3ArtifactNotFoundException(final String message, final Throwable cause, final String bucket,
+            final String key) {
+        super(message, cause);
+        this.bucket = bucket;
+        this.key = key;
+    }
+
+    /**
+     * Constructor with a cause and information about the searched artifact.
+     * 
+     * @param cause
+     *            the cause of the exception.
+     * @param bucket
+     *            the bucket of the searched artifact.
+     * @param key
+     *            the key of the searched artifact (mostly kind of
+     *            'tenant/sha1hash').
+     */
+    public S3ArtifactNotFoundException(final Throwable cause, final String bucket, final String key) {
+        super(cause);
+        this.bucket = bucket;
+        this.key = key;
+    }
+
+    /**
+     * @return key (mostly kind of 'tenant/sha1hash').
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return the bucket name
+     */
+    public String getBucket() {
+        return bucket;
+    }
+}

--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
@@ -134,7 +134,7 @@ public class S3Repository extends AbstractArtifactRepository {
         try {
             return S3Artifact.get(amazonS3, s3Properties, key, sha1Hash);
         } catch (final S3ArtifactNotFoundException e) {
-            LOG.debug("Cannot find artifact for bucket {} with key {}", e.getBucket(), e.getKey());
+            LOG.debug("Cannot find artifact for bucket {} with key {}", e.getBucket(), e.getKey(), e);
             return null;
         }
     }


### PR DESCRIPTION
Open S3Object InputStream when creating an instance of S3Artifact to make it reusable and prevent a wrong usage because of an unused open InputStream.

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>