### PR TITLE
Don't retrieve MD5 hash via etag from S3

### DIFF
--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ import com.google.common.io.BaseEncoding;
  * An {@link ArtifactRepository} implementation for the AWS S3 service. All
  * binaries are stored in single bucket using the configured name
  * {@link S3RepositoryProperties#getBucketName()}.
- * 
+ *
  * From the AWS S3 documentation:
  * <p>
  * There is no limit to the number of objects that can be stored in a bucket and
@@ -140,23 +140,12 @@ public class S3Repository extends AbstractArtifactRepository {
 
             final ObjectMetadata s3ObjectMetadata = s3Object.getObjectMetadata();
 
-            // the MD5Content is stored in the ETag
-            return new S3Artifact(amazonS3, s3Properties, key, sha1Hash,
-                    new DbArtifactHash(sha1Hash,
-                            BaseEncoding.base16().lowerCase().encode(
-                                    BaseEncoding.base64().decode(sanitizeEtag(s3ObjectMetadata.getETag()))),
-                            null),
+            return new S3Artifact(amazonS3, s3Properties, key, sha1Hash, new DbArtifactHash(sha1Hash, null, null),
                     s3ObjectMetadata.getContentLength(), s3ObjectMetadata.getContentType());
         } catch (final IOException e) {
             LOG.error("Could not verify S3Object", e);
             return null;
         }
-    }
-
-    private static String sanitizeEtag(final String etag) {
-        // base64 alphabet consist of alphanumeric characters and + / = (see RFC
-        // 4648)
-        return etag.trim().replaceAll("[^A-Za-z0-9+/=]", "");
     }
 
     @Override

--- a/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
+++ b/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
@@ -30,13 +30,14 @@ import java.util.Random;
 
 import org.eclipse.hawkbit.artifact.repository.model.AbstractDbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -48,7 +49,6 @@ import com.google.common.io.ByteStreams;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Test class for the {@link S3Repository}.
@@ -117,14 +117,10 @@ public class S3RepositoryTest {
         final String knownSHA1Hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
         final long knownContentLength = 100;
         final String knownContentType = "application/octet-stream";
-        final String knownMd5 = "098f6bcd4621d373cade4e832627b4f6";
-        final String knownMdBase16 = BaseEncoding.base16().lowerCase().encode(knownMd5.getBytes());
-        final String knownMd5Base64 = BaseEncoding.base64().encode(knownMd5.getBytes());
 
         when(amazonS3Mock.getObject(anyString(), anyString())).thenReturn(s3ObjectMock);
         when(s3ObjectMock.getObjectMetadata()).thenReturn(s3ObjectMetadataMock);
         when(s3ObjectMetadataMock.getContentLength()).thenReturn(knownContentLength);
-        when(s3ObjectMetadataMock.getETag()).thenReturn(knownMd5Base64);
         when(s3ObjectMetadataMock.getContentType()).thenReturn(knownContentType);
 
         // test
@@ -135,25 +131,6 @@ public class S3RepositoryTest {
         assertThat(artifactBySha1.getContentType()).isEqualTo(knownContentType);
         assertThat(artifactBySha1.getSize()).isEqualTo(knownContentLength);
         assertThat(artifactBySha1.getHashes().getSha1()).isEqualTo(knownSHA1Hash);
-        assertThat(artifactBySha1.getHashes().getMd5()).isEqualTo(knownMdBase16);
-    }
-
-    @Test
-    @Description("Verifies that special characters in the etag are sanitized")
-    public void getArtifactBySHA1SanitizeEtag() {
-        final String knownSHA1Hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
-        final String knownMd5 = "098f6bcd4621d373cade4e832627b4f6";
-        final String knownMdBase16 = BaseEncoding.base16().lowerCase().encode(knownMd5.getBytes());
-        final String knownMd5Base64 = BaseEncoding.base64().encode(knownMd5.getBytes());
-
-        when(amazonS3Mock.getObject(anyString(), anyString())).thenReturn(s3ObjectMock);
-        when(s3ObjectMock.getObjectMetadata()).thenReturn(s3ObjectMetadataMock);
-        // add special characters to etag
-        when(s3ObjectMetadataMock.getETag()).thenReturn("'" + knownMd5Base64 + "'");
-
-        final AbstractDbArtifact artifactBySha1 = s3RepositoryUnderTest.getArtifactBySha1(TENANT, knownSHA1Hash);
-
-        assertThat(artifactBySha1.getHashes().getMd5()).isEqualTo(knownMdBase16);
     }
 
     @Test


### PR DESCRIPTION
Currently, we retrieve the MD5 hash from etag in the method `getArtifactBySha1`. The [official AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html) states that _The ETag may or may not be an MD5 digest of the object data_. 
In the S3 extension the etag is base64 decoded and afterwards base16 encoded. This leads to a wrong value, as the etag value coming from S3 is already base16 encoded. The created value will not have the expected 32 characters.
However with [this PR](https://github.com/eclipse/hawkbit/pull/1158) the MD5 hash coming from retrieved S3 objects will be written to database. When the MD5 digest is empty, the calculated hash will be written to database instead. As the encoded/decoded MD5 hash retrieved from etag has more than the expected 32 characters, this leads to a database constraint violation, and already existing artifacts can't be added to additional software modules.
Therefore, the MD5 value is set to `null` with this PR, as the MD5 digest coming from the etag is not used at all.

Signed-off-by: Sebastian Firsching <sebastian.firsching@bosch-si.com>