### PR TITLE
Azure quick start: update kubernetes version, cert-manager api and k8s networking api

### DIFF
--- a/hawkbit-extended-runtimes/hawkbit-update-server-azure/deployment/arm/hawkBitInfrastructureDeployment.json
+++ b/hawkbit-extended-runtimes/hawkbit-update-server-azure/deployment/arm/hawkBitInfrastructureDeployment.json
@@ -255,6 +255,9 @@
                     "uri": "https://raw.githubusercontent.com/eclipse/hawkbit-extensions/master/hawkbit-extended-runtimes/hawkbit-update-server-azure/deployment/arm/templates/kubernetesDeploy.json"
                 },
                 "parameters": {
+					"kubernetesVersion": {
+                        "value": "1.22.6"
+                    },
                     "clusterName": {
                         "value": "[variables('aksClusterName')]"
                     },

--- a/hawkbit-extended-runtimes/hawkbit-update-server-azure/deployment/arm/templates/kubernetesDeploy.json
+++ b/hawkbit-extended-runtimes/hawkbit-update-server-azure/deployment/arm/templates/kubernetesDeploy.json
@@ -4,7 +4,7 @@
   "parameters": {
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.17.9",
+      "defaultValue": "1.22.6",
       "metadata": {
         "description": "Kubernetes version."
       }

--- a/hawkbit-extended-runtimes/hawkbit-update-server-azure/deployment/helm/hawkbit/templates/ingress.yaml
+++ b/hawkbit-extended-runtimes/hawkbit-update-server-azure/deployment/helm/hawkbit/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hawkbit.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -30,15 +30,18 @@ spec:
         paths:
 	{{- range $ingressPaths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
 	{{- end }}
   {{- end }}
 {{- end }}
 {{- if .Values.ingress.tls.enabled }}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-prod
@@ -53,7 +56,7 @@ spec:
         ingress:
           class: nginx
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-staging


### PR DESCRIPTION
Hi, I just tried the [Azure extension quickstart](https://github.com/eclipse/hawkbit-extensions/tree/master/hawkbit-extended-runtimes/hawkbit-update-server-azure) and needed to make a few minor changes to get it working.

I needed to update the following versions:
kubernetes 1.17.9 -> 1.22.6
networking.k8s.io/v1beta1 -> networking.k8s.io/v1
cert-manager.io/v1alpha2 -> cert-manager.io/v1

Kubernetes 1.17.9 is not available anymore at Azure.