### PR TITLE
Replacing self-managed SonarQube with Sonarcloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     working_directory: ~/hawkBit-extensions
 
     docker:
-    - image: circleci/openjdk:openjdk:11.0.13-jdk-buster
+    - image: circleci/openjdk:11.0.13-jdk-buster
       auth:
         username: $DOCKERHUB_USER
         password: $DOCKERHUB_ACCESSTOKEN

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.3.0.bosch81</version>
     </parent>
 
     <artifactId>hawkbit-extensions-parent</artifactId>
@@ -41,7 +41,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
+      <hawkbit.version>0.3.0.bosch81</hawkbit.version>
       <aws.sdk.version>1.11.415</aws.sdk.version>
       <gcp.sdk.version>0.77.0-alpha</gcp.sdk.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
     </distributionManagement>
 
    <properties>
+      <!-- ************************ -->
+      <!-- Build/Release settings -->
+      <!-- ************************ -->
+      <maven.sonar.plugin.version>3.9.1.2184</maven.sonar.plugin.version>   
 
       <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <aws.sdk.version>1.11.415</aws.sdk.version>
@@ -75,6 +79,19 @@
     </modules>
 
     <build>
+    
+      <pluginManagement>
+         <plugins>      
+        	<!-- override groupid that is set in maven to supress warning regarding relocation of sonar-maven-plugin -->
+	    	<!-- see https://stackoverflow.com/a/35289210 -->
+            <plugin>
+               <groupId>org.sonarsource.scanner.maven</groupId>
+               <artifactId>sonar-maven-plugin</artifactId>
+               <version>${maven.sonar.plugin.version}</version>
+            </plugin> 
+         </plugins>
+      </pluginManagement>    
+    
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,6 @@
     </distributionManagement>
 
    <properties>
-      <!-- ************************ -->
-      <!-- Build/Release settings -->
-      <!-- ************************ -->
-      <maven.sonar.plugin.version>3.9.1.2184</maven.sonar.plugin.version>   
-
       <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <aws.sdk.version>1.11.415</aws.sdk.version>
       <gcp.sdk.version>0.77.0-alpha</gcp.sdk.version>
@@ -79,19 +74,6 @@
     </modules>
 
     <build>
-    
-      <pluginManagement>
-         <plugins>      
-        	<!-- override groupid that is set in maven to supress warning regarding relocation of sonar-maven-plugin -->
-	    	<!-- see https://stackoverflow.com/a/35289210 -->
-            <plugin>
-               <groupId>org.sonarsource.scanner.maven</groupId>
-               <artifactId>sonar-maven-plugin</artifactId>
-               <version>${maven.sonar.plugin.version}</version>
-            </plugin> 
-         </plugins>
-      </pluginManagement>    
-    
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0.bosch81</version>
+      <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hawkbit-extensions-parent</artifactId>
@@ -41,7 +41,7 @@
 
    <properties>
 
-      <hawkbit.version>0.3.0.bosch81</hawkbit.version>
+      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <aws.sdk.version>1.11.415</aws.sdk.version>
       <gcp.sdk.version>0.77.0-alpha</gcp.sdk.version>
 
@@ -52,7 +52,6 @@
       <!-- Release - END -->
 
       <!-- Sonar - START -->
-      <sonar.github.repository>eclipse/hawkbit-extensions</sonar.github.repository>
       <sonar.links.ci>https://circleci.com/gh/eclipse/hawkbit-extensions</sonar.links.ci>
 
        <!-- Override Sonar/Reporting settings -->


### PR DESCRIPTION
This PR contains the changes to replace the self-managed SonarQube with Sonarcloud for this repository.