### PR TITLE
Add GitHub workflow that smoke-builds all extensions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: Build against current HawkBit
+
+on:
+  pull_request:
+
+jobs:
+  build-without-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Smoke build in docker
+        uses: docker/build-push-action@v3
+        with:
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04 AS build
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y openjdk-11-jdk-headless maven git
+
+WORKDIR /src
+RUN git clone https://github.com/eclipse/hawkbit
+WORKDIR /src/hawkbit
+RUN mvn --quiet --batch-mode --threads 1C dependency:go-offline dependency:resolve-plugins
+RUN mvn --quiet --batch-mode --threads 1C --define=skipTests package
+RUN mvn --quiet --batch-mode --threads 1C --define=skipTests --offline install
+
+WORKDIR /src/hawkbit-extensions
+COPY . .
+RUN mvn --quiet --batch-mode --threads 1C dependency:go-offline dependency:resolve-plugins
+RUN mvn --quiet --batch-mode --threads 1C package
+RUN mvn --quiet --batch-mode --threads 1C --offline install


### PR DESCRIPTION
This is known to pass, today, on x86_64 and fail on aarch64 due to https://github.com/eclipse/hawkbit-extensions/issues/84

Since the goal is to test unreleased HawkBit + unreleased HawkBit extensions, both are built in sequence to satisfy dependencies that are not available through maven as releases.

HawkBit tests are skipped to speed up the build process.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>