### PR TITLE
Depend on com.amazonaws.aws-java-sdk-sts

### DIFF
--- a/hawkbit-extension-artifact-repository-s3/pom.xml
+++ b/hawkbit-extension-artifact-repository-s3/pom.xml
@@ -34,6 +34,11 @@
          <artifactId>aws-java-sdk-core</artifactId>
       </dependency>
       <dependency>
+         <!-- STS is required for authenticating to S3 with a web identity token -->
+         <groupId>com.amazonaws</groupId>
+         <artifactId>aws-java-sdk-sts</artifactId>
+      </dependency>
+      <dependency>
          <groupId>com.google.guava</groupId>
          <artifactId>guava</artifactId>
       </dependency>


### PR DESCRIPTION
This allows using real AWS S3 with a web identity token. See [1] for details. Absence of this dependency requires using less desired password-based authentication.

[1] https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/STSProfileCredentialsServiceLoader.java#L20

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>