### PR TITLE
s3: implement artifact range requests

### DIFF
--- a/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
+++ b/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
@@ -15,6 +15,7 @@ import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
 import org.springframework.util.Assert;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 
 /**
  * An {@link AbstractDbArtifact} implementation which retrieves the
@@ -39,7 +40,18 @@ public class S3Artifact extends AbstractDbArtifact {
 
     @Override
     public InputStream getFileInputStream() {
-        return amazonS3.getObject(s3Properties.getBucketName(), key).getObjectContent();
+        var req = new GetObjectRequest(s3Properties.getBucketName(), key);
+        var obj = amazonS3.getObject(req);
+
+        return obj.getObjectContent();
+    }
+
+    @Override
+    public InputStream getFileInputStream(long start, long end) {
+        var req = new GetObjectRequest(s3Properties.getBucketName(), key).withRange(start, end);
+        var obj = amazonS3.getObject(req);
+
+        return obj.getObjectContent();
     }
 
     @Override


### PR DESCRIPTION
The basic itent is to allow expressing an input stream for a fragment that corresponds to a single range request.

This patch is not ready to land, because it requires lock-step update in HawkBit proper. The long story short, is that the current abstraction of getFileInputStream is just insufficient to efficiently implement range requests for artifacts.

There are two goals for efficiency:

- We should not request or discard data we do not need
- We read all the data we requested and close the stream properly

The second problem is somewhat elusive, since S3 input stream has a close() method that informs us of incorrect usage if not all content is drained, when S3 is sending the content but are are not reading.

Corresponging HawkBit change is posted to HawkBit in a separate patch.

Fixes: https://github.com/eclipse/hawkbit-extensions/issues/91